### PR TITLE
Add better HTTP tests

### DIFF
--- a/src/Concerns/MakesHTTPRequests.php
+++ b/src/Concerns/MakesHTTPRequests.php
@@ -108,12 +108,11 @@ trait MakesHTTPRequests
      */
     private function _call($method, $uri, $params = [])
     {
-        //if (! str_begins_with('/', $uri) && ! str_begins_with('http', $uri)) {
-        //    var_dump('user is ' . ($GLOBALS['user'] ? $GLOBALS['user']->uid : ' not available'));
-        //    $client = new MenuCaller();
-        //
-        //    return $client->setPath($uri)->setMethod($method)->addParams($params)->send();
-        //}
+        if (! str_begins_with('http', $uri)) {
+            $client = new MenuCaller();
+
+            return $client->setPath($uri)->setMethod($method)->addParams($params)->send();
+        }
 
         try {
             $client = new Client();

--- a/src/Services/MenuCaller.php
+++ b/src/Services/MenuCaller.php
@@ -18,7 +18,7 @@ class MenuCaller
      *
      * @var array
      */
-    protected $params;
+    protected $params = [];
 
     /**
      * POST, GET, PUT, PATCH, DELETE.
@@ -48,7 +48,12 @@ class MenuCaller
      */
     public function setPath($path)
     {
-        $this->path = $path === '/' ? $path : trim($path, '/');
+        $this->path = trim($path, '/');
+
+        if(empty($this->path)) {
+            // Home page requested so let's use /node
+            $this->path = 'node';
+        }
 
         return $this;
     }
@@ -161,7 +166,7 @@ class MenuCaller
             drupal_access_denied();
             ob_end_clean();
         } elseif (empty($value)) {
-            $value = render($buffer);
+            $value = drupal_render_page($buffer);
         }
 
         return [
@@ -177,10 +182,7 @@ class MenuCaller
     protected function injectParams()
     {
         $_GET['q'] = $this->path;
-
-        if (! $this->params) {
-            return;
-        }
+        $_SERVER['REQUEST_URI'] = $this->path;
 
         if (in_array($this->method, ['GET', 'DELETE'])) {
             foreach ($this->params as $key => $param) {

--- a/tests/test_module/sites/default/files/tripal/ws/context/doc.v0_1.json
+++ b/tests/test_module/sites/default/files/tripal/ws/context/doc.v0_1.json
@@ -1,0 +1,1 @@
+{"@context":{"rdfs":"http:\/\/www.w3.org\/2000\/01\/rdf-schema#","hydra":"http:\/\/www.w3.org\/ns\/hydra\/core#","dc":"http:\/\/purl.org\/dc\/terms\/","schema":"https:\/\/schema.org\/","local":"http:\/\/localhost\/cv\/lookup\/local\/","vocab":"http:\/\/localhost\/web-services\/doc\/v0.1#","EntryPoint":"vocab:EntryPoint"}}

--- a/tests/test_module/sites/default/files/tripal/ws/context/services..json
+++ b/tests/test_module/sites/default/files/tripal/ws/context/services..json
@@ -1,0 +1,1 @@
+{"@context":{"rdfs":"http:\/\/www.w3.org\/2000\/01\/rdf-schema#","hydra":"http:\/\/www.w3.org\/ns\/hydra\/core#","dc":"http:\/\/purl.org\/dc\/terms\/","schema":"https:\/\/schema.org\/","local":"http:\/\/localhost\/cv\/lookup\/local\/","error":"rdfs:error"}}

--- a/tests/test_module/tests/Feature/TestResponseTest.php
+++ b/tests/test_module/tests/Feature/TestResponseTest.php
@@ -64,21 +64,4 @@ class TestResponseTest extends TripalTestCase
     {
         $this->response->assertSee('values');
     }
-
-
-    /** @test */
-    public function testPublicRoute()
-    {
-        $response = $this->get('testing/test_module');
-
-        $response->assertSuccessful()->assertSee('testing html');
-    }
-
-    /** @test */
-    public function testRequestForm()
-    {
-        $response = $this->get('testing/test_module_form');
-
-        $response->assertSuccessful()->assertSee('Please enter your first name.');
-    }
 }

--- a/tests/test_module/tests/Feature/TripalTestCaseHTTPTest.php
+++ b/tests/test_module/tests/Feature/TripalTestCaseHTTPTest.php
@@ -20,6 +20,8 @@ class TripalTestCaseHTTPTest extends TripalTestCase
     {
         $response = $this->get('/');
         $this->assertTrue($response instanceof TestResponse);
+        $response->assertSuccessful()
+        ->assertSee(variable_get('site_name'));
     }
 
     /** @test */
@@ -53,7 +55,7 @@ class TripalTestCaseHTTPTest extends TripalTestCase
     /** @test */
     public function testNotFoundRoute()
     {
-        $response = $this->get('/never-in-am-million-years');
+        $response = $this->get('/never-in-a-million-years-will-this-page-exist-'.uniqid());
 
         $response->assertStatus(404);
     }

--- a/tests/test_module/tests/Feature/TripalTestCaseHTTPTest.php
+++ b/tests/test_module/tests/Feature/TripalTestCaseHTTPTest.php
@@ -16,12 +16,6 @@ class TripalTestCaseHTTPTest extends TripalTestCase
     }
 
     /** @test */
-    public function testThatGetMethodExists()
-    {
-        $this->assertTrue(method_exists($this, 'get'));
-    }
-
-    /** @test */
     public function testThatGetMethodReturnsTestResponse()
     {
         $response = $this->get('/');
@@ -54,5 +48,44 @@ class TripalTestCaseHTTPTest extends TripalTestCase
     {
         $response = $this->patch('/');
         $this->assertTrue($response instanceof TestResponse);
+    }
+
+    /** @test */
+    public function testNotFoundRoute()
+    {
+        $response = $this->get('/never-in-am-million-years');
+
+        $response->assertStatus(404);
+    }
+
+    /** @test */
+    public function testUnauthorizedAccess()
+    {
+        $response = $this->get('/admin');
+        $response->assertStatus(403);
+    }
+
+    /** @test */
+    public function testAdminAccess()
+    {
+        $this->actingAs(1);
+        $response = $this->get('/admin');
+        $response->assertStatus(200);
+    }
+
+    /** @test */
+    public function testPublicRoute()
+    {
+        $response = $this->get('testing/test_module');
+
+        $response->assertSuccessful()->assertSee('testing html');
+    }
+
+    /** @test */
+    public function testRequestForm()
+    {
+        $response = $this->get('testing/test_module_form');
+
+        $response->assertSuccessful()->assertSee('Please enter your first name.');
     }
 }


### PR DESCRIPTION
With this PR, `actingAs` and `DBTransaction` features work alongside http testing. This makes testing APIs and general pages a lot easier. We could for example create an entity, attach a custom field then visit the page to make sure the field prints accurate information. All without exiting the IDE.