### PR TITLE
Add a warning in docs for DB Transactions when using dataProviders

### DIFF
--- a/docs/source/db-transactions.rst
+++ b/docs/source/db-transactions.rst
@@ -25,5 +25,11 @@ The trait will automatically activate DB transactions and rollback the database 
 
 .. warning::
 
+	Using ``@dataProvider`` does not honor database transactions.
+	If your dataProvider creates database records, call it directly
+	in the test function instead of using ``@dataProvider`` in you doc block.
+
+.. warning::
+
 	If the code you are testing requires a transaction, Postgres
 	will fail since it does not support nested transactions.


### PR DESCRIPTION
See discussion in #136 

This adds a warning in the documentation about using dataProviders with DBTransaction.